### PR TITLE
feat: end time key, code improvements

### DIFF
--- a/addons/sourcemod/scripting/zr_personal_skins.sp
+++ b/addons/sourcemod/scripting/zr_personal_skins.sp
@@ -8,8 +8,6 @@
 #include <zombiereloaded>
 #include <utilshelper>
 
-#define DATE_FORMAT "%m/%d/%Y - %H:%M:%S"
-
 //#define DEBUG
 
 /* CVARS */
@@ -24,7 +22,8 @@ ConVar g_cvClassIdentifierZombieVIP;
 ConVar g_cvClassIdentifierHumanVIP;
 ConVar g_cvTeamMode;
 
-enum struct PlayerData {
+enum struct PlayerData
+{
 	bool hasZombie;
 	bool hasHuman;
 	
@@ -34,7 +33,8 @@ enum struct PlayerData {
 	int endZombie;
 	int endHuman;
 	
-	void Reset() {
+	void Reset()
+	{
 		this.hasZombie = false; 
 		this.hasHuman = false;
 		this.modelZombie[0] = '\0';
@@ -57,20 +57,23 @@ char g_sClassIdentifierZombieVIP[64];
 /* Keyvalues */
 KeyValues g_hKV;
 
-public Plugin myinfo = {
+public Plugin myinfo =
+{
 	name = "[ZR] Personal Skins",
 	description = "Gives a personal human or zombie skin",
-	author = "FrozDark, maxime1907, .Rushaway, Dolly, zaCade (Remade by Dolly)",
+	author = "FrozDark, maxime1907, .Rushaway, Dolly, zaCade",
 	version = "2.2.3",
 	url = ""
 };
 
-public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max) {
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
 	RegPluginLibrary("ZR_PersonalSkins");
 	return APLRes_Success;
 }
 
-public void OnPluginStart() {
+public void OnPluginStart()
+{
 	/* Paths Configs */
 	g_cvDownListPath 		= CreateConVar("zr_personalskins_downloadslist", "addons/sourcemod/configs/zr_personalskins_downloadslist.txt", "Config path of the download list", FCVAR_NONE);
 	g_cvFileSettingsPath 	= CreateConVar("zr_personalskins_skinslist", "addons/sourcemod/data/zr_personal_skins.txt", "Config path of the skin settings", FCVAR_NONE);
@@ -86,18 +89,18 @@ public void OnPluginStart() {
 	g_cvClassIdentifierHumanVIP 	= CreateConVar("zr_personalskins_group_human_vip", "Personal-Skin-Human-VIP", "Class identifier name for personal skin human VIP", FCVAR_PROTECTED);
 	g_cvTeamMode 					= CreateConVar("zr_personalskins_team_mode", "0", "0: validation par class identifier, 1: validation par team (T=zm, CT=human)", FCVAR_NONE, true, 0.0, true, 1.0);
 
-	g_cvFileSettingsPath			.AddChangeHook(OnConVarChange);
-	g_cvClassIdentifierZombie		.AddChangeHook(OnConVarChange);
-	g_cvClassIdentifierHuman		.AddChangeHook(OnConVarChange);
-	g_cvClassIdentifierZombieVIP	.AddChangeHook(OnConVarChange);
-	g_cvClassIdentifierHumanVIP		.AddChangeHook(OnConVarChange);
+	g_cvFileSettingsPath.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierZombie.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierHuman.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierZombieVIP.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierHumanVIP.AddChangeHook(OnConVarChange);
 	
 	/* Initialize values + Handle plugin reload */
-	g_cvFileSettingsPath			.GetString(g_sFileSettingsPath, sizeof(g_sFileSettingsPath));
-	g_cvClassIdentifierZombie		.GetString(g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie));
-	g_cvClassIdentifierHuman		.GetString(g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman));
-	g_cvClassIdentifierZombieVIP	.GetString(g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP));
-	g_cvClassIdentifierHumanVIP		.GetString(g_sClassIdentifierHumanVIP, sizeof(g_sClassIdentifierHumanVIP));
+	g_cvFileSettingsPath.GetString(g_sFileSettingsPath, sizeof(g_sFileSettingsPath));
+	g_cvClassIdentifierZombie.GetString(g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie));
+	g_cvClassIdentifierHuman.GetString(g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman));
+	g_cvClassIdentifierZombieVIP.GetString(g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP));
+	g_cvClassIdentifierHumanVIP.GetString(g_sClassIdentifierHumanVIP, sizeof(g_sClassIdentifierHumanVIP));
 	
 	RegAdminCmd("zr_pskins_reload", Command_Reload, ADMFLAG_ROOT);
 	RegConsoleCmd("sm_pskin", Command_pSkin);
@@ -106,7 +109,8 @@ public void OnPluginStart() {
 }
 
 /* Map End */
-public void OnMapEnd() {
+public void OnMapEnd()
+{
 	delete g_hKV;
 
 	// Restore cvar to 1, this is helpful when a specified team (or both) personal skin is/are disabled during a map, somehow cvars stay with the same value
@@ -115,18 +119,21 @@ public void OnMapEnd() {
 }
 
 /* Client Disconnect */
-public void OnClientDisconnect(int client) {
+public void OnClientDisconnect(int client)
+{
 	g_PlayerData[client].Reset();
 }
 
 /* Read the data file */
-public void OnConfigsExecuted() {
+public void OnConfigsExecuted()
+{
 	char downloadPath[PLATFORM_MAX_PATH];
 	g_cvDownListPath.GetString(downloadPath, sizeof(downloadPath));
 
 	g_hKV = new KeyValues("SkinSettings");
 	
-	if(!g_hKV.ImportFromFile(g_sFileSettingsPath)) {
+	if(!g_hKV.ImportFromFile(g_sFileSettingsPath))
+	{
 		SetFailState("[ZR-Personal Skins] File '%s' not found!", g_sFileSettingsPath);
 		delete g_hKV;
 		return;
@@ -142,47 +149,53 @@ public void OnConfigsExecuted() {
 }
 
 /* Update settings path when it is changed */
-public void OnConVarChange(ConVar convar, const char[] oldValue, const char[] newValue) {
-	if(convar == g_cvFileSettingsPath) {
+public void OnConVarChange(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if(convar == g_cvFileSettingsPath)
+	{
 		strcopy(g_sFileSettingsPath, sizeof(g_sFileSettingsPath), newValue);
 		ClearKV(g_hKV);
 		
-		if (!g_hKV.ImportFromFile(g_sFileSettingsPath)) {
+		if (!g_hKV.ImportFromFile(g_sFileSettingsPath))
 			SetFailState("[ZR-Personal Skins] File '%s' not found!", g_sFileSettingsPath);
-		}
-		
+			
 		return;
 	}
 	
-	if (convar == g_cvClassIdentifierZombie) {
+	if (convar == g_cvClassIdentifierZombie)
+	{
 		strcopy(g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie), newValue);
 		return;
 	}
 	
-	if(convar == g_cvClassIdentifierHuman) {
+	if(convar == g_cvClassIdentifierHuman)
+	{
 		strcopy(g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman), newValue);
 		return;
 	}
 	
-	if (convar == g_cvClassIdentifierZombieVIP) {
+	if (convar == g_cvClassIdentifierZombieVIP)
+	{
 		strcopy(g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP), newValue);
 		return;
 	}
 
-	if (convar == g_cvClassIdentifierHumanVIP) {
+	if (convar == g_cvClassIdentifierHumanVIP)
+	{
 		strcopy(g_sClassIdentifierHumanVIP, sizeof(g_sClassIdentifierHumanVIP), newValue);
 		return;
 	}
 }
 
 /* Commands */
-public Action Command_Reload(int client, int args) {
-	if(g_hKV == null) {
+public Action Command_Reload(int client, int args)
+{
+	if(g_hKV == null) 
 		return Plugin_Handled;
-	}
 
 	ClearKV(g_hKV);
-	if(!g_hKV.ImportFromFile(g_sFileSettingsPath)) {
+	if(!g_hKV.ImportFromFile(g_sFileSettingsPath))
+	{
 		CReplyToCommand(client, "{green}[ZR] {red}File '%s' not found!", g_sFileSettingsPath);
 		SetFailState("[ZR-Personal Skins] File '%s' not found!", g_sFileSettingsPath);
 		return Plugin_Handled;
@@ -193,26 +206,25 @@ public Action Command_Reload(int client, int args) {
 	return Plugin_Handled;
 }
 
-public Action Command_pSkin(int client, int args) {
-	if (!client) {
+public Action Command_pSkin(int client, int args)
+{
+	if (!client)
 		return Plugin_Handled;
-	}
 
-	if (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman) {
+	if (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman) 
 		CReplyToCommand(client, "{green}[ZR] {default}You don't have personal-skin");
-	} else {
+	else 
 		ZR_MenuClass(client);
-	}
 	
 	return Plugin_Handled;
 }
 
 // We use this instead of PostAdminCheck, bcs ZombieReloaded check class on post.
 // Need to give the groups used as filter in playerclass before ZR check if user can access to it.
-public void OnClientPostAdminFilter(int client) {
-	if (g_hKV == null || IsFakeClient(client)) {
+public void OnClientPostAdminFilter(int client)
+{
+	if (g_hKV == null || IsFakeClient(client))
 		return;
-	}
 	
 	char steamID[24], ip[16], name[64];
 
@@ -220,76 +232,82 @@ public void OnClientPostAdminFilter(int client) {
 		return;
 
 	g_hKV.Rewind();
-	if(!g_hKV.JumpToKey(steamID) && !g_hKV.JumpToKey(ip) && !g_hKV.JumpToKey(name)) {
+	if(!g_hKV.JumpToKey(steamID) && !g_hKV.JumpToKey(ip) && !g_hKV.JumpToKey(name))
 		return;
-	}
 	
 	/* Get Zombie Personal Skin Info */
 	int zmSkinEndTime;
-	if(ValidatePersonalSkin(client, "ModelZombie", "end_zombie", g_PlayerData[client].modelZombie, sizeof(PlayerData::modelZombie), zmSkinEndTime)) {
+	if(ValidatePersonalSkin(client, "ModelZombie", "end_zombie", g_PlayerData[client].modelZombie, sizeof(PlayerData::modelZombie), zmSkinEndTime))
+	{
 		g_PlayerData[client].hasZombie = true;
-		if(zmSkinEndTime > 0) {
+		if(zmSkinEndTime > 0) 
 			g_PlayerData[client].endZombie = zmSkinEndTime;
-		}
-	} else {
+	}
+	else 
+	{
 		#if defined DEBUG
 		PrintToServer("[ZR-Personal Skins] Could not Validate Zombie skin for %N, skin has probably ended", client);
 		#endif
 	}
 	
 	int humanEndTime;
-	if(ValidatePersonalSkin(client, "ModelHuman", "end_human", g_PlayerData[client].modelHuman, sizeof(PlayerData::modelHuman), humanEndTime)) {
+	if(ValidatePersonalSkin(client, "ModelHuman", "end_human", g_PlayerData[client].modelHuman, sizeof(PlayerData::modelHuman), humanEndTime))
+	{
 		g_PlayerData[client].hasHuman = true;
-		if(humanEndTime > 0) {
+		if(humanEndTime > 0)
 			g_PlayerData[client].endHuman = humanEndTime;
-		}
-	} else {
+	} 
+	else
+	{
 		#if defined DEBUG
 		PrintToServer("[ZR-Personal Skins] Could not Validate Human skin for %N, skin has probably ended", client);
 		#endif
 	}
 	
 	// No personal-skin found for this player - Stop here
-	if (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman) {
+	if (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman)
 		return;
-	}
 
 	GrantCustom5Flag(client);
 }
 
 /* To validate if the player can use the personal skin or not */
-bool ValidatePersonalSkin(int client, const char[] modelKey, const char[] endKey, char[] model, int maxlen, int &skinEndTime = 0) {
+bool ValidatePersonalSkin(int client, const char[] modelKey, const char[] endKey, char[] model, int maxlen, int &skinEndTime = 0)
+{
 	if(g_hKV.GetString(modelKey, model, maxlen)
-		&& strlen(model) != 0) {
+		&& strlen(model) != 0)
+	{
 		bool has = false;
-		char endTime[24];
-		g_hKV.GetString(endKey, endTime, sizeof(endTime));
-		if(endTime[0]) {
+		int endTime = g_hKV.GetNum(endKey, 0);
+		if(endTime != 0)
+		{
 			// for end time (useful if skin was rewarded during an event and there is an end for it)
 			// be careful with the date format otherwise the function will return an error
 			#if defined DEBUG
-			PrintToServer("[ZR-Personal Skins] End Time for %N: %s", client, endTime);
+			PrintToServer("[ZR-Personal Skins] End Time for %N: %d", client, endTime);
 			#endif
-			int endTimeStamp = ParseTime(endTime, DATE_FORMAT);
-			if(endTimeStamp > GetTime()) {
+			if(endTime > GetTime())
+			{
 				has = true;
-				skinEndTime = endTimeStamp;
+				skinEndTime = endTime;
 			}
-		} else {
+		}
+		else
+		{
 			has = true;
 		}
 		
-		if(has) {
+		if(has)
+		{
 			if (!IsModelFile(model))
 			{
 				LogError("[ZR-Personal Skins] %L Personal Skins (Zombie) is not a model file. (.mdl)", client);
 				has = false;
 			}
 
-			if (has && !IsModelPrecached(model)) {
+			if (has && !IsModelPrecached(model))
 				PrecacheModel(model, false);
-			}
-
+		
 			return has;
 		}
 	}
@@ -297,54 +315,57 @@ bool ValidatePersonalSkin(int client, const char[] modelKey, const char[] endKey
 	return false;
 }
 
-public void OnRebuildAdminCache(AdminCachePart part) {
-	if (part != AdminCache_Admins) {
+public void OnRebuildAdminCache(AdminCachePart part)
+{
+	if (part != AdminCache_Admins)
 		return;
-	}
 
-	for (int client = 1; client <= MaxClients; client++) {
-		if (!IsClientInGame(client) || IsFakeClient(client) || (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman)) {
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (!IsClientInGame(client) || IsFakeClient(client) || (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman))
 			continue;
-		}
 
 		GrantCustom5Flag(client);
 	}
 }
 
-void GrantCustom5Flag(int client) {
+void GrantCustom5Flag(int client)
+{
 	int flags = GetUserFlagBits(client);
-	if (!(flags & ADMFLAG_CUSTOM5)) {
+	if (!(flags & ADMFLAG_CUSTOM5))
+	{
 		flags |= ADMFLAG_CUSTOM5;
 		SetUserFlagBits(client, flags);
+		#if defined DEBUG
 		LogMessage("[ZR-Personal Skins] Granted custom5 flag to %L", client);
+		#endif
 	}
 }
 
-public void ZR_OnClassAttributesApplied(int &client, int &classindex) {
+public void ZR_OnClassAttributesApplied(int &client, int &classindex)
+{
 	#if defined DEBUG
 	LogMessage("[ZR-Personal Skins] ZR_OnClassAttributesApplied: %d | %d", client, classindex);
 	#endif
 
-	if(!IsValidClient(client) || !IsPlayerAlive(client) || !(g_PlayerData[client].hasZombie || g_PlayerData[client].hasHuman)) {
+	if(!IsValidClient(client) || !IsPlayerAlive(client) || !(g_PlayerData[client].hasZombie || g_PlayerData[client].hasHuman))
 		return;
-	}
 	
 	bool zm = ZR_IsClientZombie(client);
-	if(zm && (!g_cvZombies.BoolValue || !g_PlayerData[client].hasZombie || (g_PlayerData[client].endZombie > 0 && g_PlayerData[client].endZombie <= GetTime()))) {
+	if(zm && (!g_cvZombies.BoolValue || !g_PlayerData[client].hasZombie || (g_PlayerData[client].endZombie > 0 && g_PlayerData[client].endZombie <= GetTime())))
 		return;
-	}
 	
-	if(!zm && (!g_cvHumans.BoolValue || g_PlayerData[client].hasHuman || (g_PlayerData[client].endHuman > 0 && g_PlayerData[client].endHuman <= GetTime()))) {
+	if(!zm && (!g_cvHumans.BoolValue || !g_PlayerData[client].hasHuman || (g_PlayerData[client].endHuman > 0 && g_PlayerData[client].endHuman <= GetTime())))
 		return;
-	}
-	
+		
 	char modelpath[PLATFORM_MAX_PATH];
-	switch (g_cvTeamMode.IntValue) {
-		case 0: {
+	switch (g_cvTeamMode.IntValue)
+	{
+		case 0: 
+		{
 			int activeClass = ZR_GetActiveClass(client);
-			if(!ZR_IsValidClassIndex(activeClass)) {
+			if(!ZR_IsValidClassIndex(activeClass))
 				return;
-			}
 			
 			int personalHumanClass 		= ZR_GetClassByIdentifier(g_sClassIdentifierHuman);
 			int personalZombieClass 	= ZR_GetClassByIdentifier(g_sClassIdentifierZombie);
@@ -359,29 +380,32 @@ public void ZR_OnClassAttributesApplied(int &client, int &classindex) {
 				LogMessage("[ZR-Personal Skins] Personal zombie VIP: %d", personalZombieClassVIP);
 			#endif
 			
-			if(zm) {
-				if(activeClass != personalZombieClass && activeClass != personalZombieClassVIP) {
+			if(zm)
+			{
+				if(activeClass != personalZombieClass && activeClass != personalZombieClassVIP)
 					return;
-				}
 				
 				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelZombie);
-			} else {
-				if(activeClass != personalHumanClass && activeClass != personalHumanClassVIP) {
+			} 
+			else
+			{
+				if(activeClass != personalHumanClass && activeClass != personalHumanClassVIP)
 					return;
-				}
 				
 				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelHuman);
 			}
 		}
 		
-		case 1: {
+		case 1:
+		{
 			if (zm)
 				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelZombie);
 			else
 				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelHuman);
 		}
 		
-		default: return;
+		default: 
+			return;
 	}
 
 	// Player has a Personal-Skin but no model related to the current team or model_path wasn't set.
@@ -422,18 +446,18 @@ public void ZR_OnClassAttributesApplied(int &client, int &classindex) {
 	SetEntityModel(client, modelpath);
 }
 
-void ClearKV(KeyValues kv) {
-	if(kv == null) {
+void ClearKV(KeyValues kv)
+{
+	if(kv == null)
 		return;
-	}
 	
 	kv.Rewind();
 
-	if(!kv.GotoFirstSubKey()) {
+	if(!kv.GotoFirstSubKey())
 		return;
-	}
 
-	do {
+	do 
+	{
 		kv.DeleteThis();
 		kv.Rewind();
 	}
@@ -442,15 +466,18 @@ void ClearKV(KeyValues kv) {
 	kv.Rewind();
 }
 
-bool IsModelFile(char[] model) {
+bool IsModelFile(char[] model)
+{
 	char buf[4];
 	GetExtension(model, buf, sizeof(buf));
 	return !strcmp(buf, "mdl", false);
 }
 
-void GetExtension(char[] path, char[] buffer, int size) {
+void GetExtension(char[] path, char[] buffer, int size)
+{
 	int extpos = FindCharInString(path, '.', true);
-	if (extpos == -1) {
+	if (extpos == -1)
+	{
 		buffer[0] = '\0';
 		return;
 	}

--- a/addons/sourcemod/scripting/zr_personal_skins.sp
+++ b/addons/sourcemod/scripting/zr_personal_skins.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include <sdktools>
 #include <smlib>
@@ -5,413 +8,467 @@
 #include <zombiereloaded>
 #include <utilshelper>
 
-#pragma semicolon 1
-#pragma newdecls required
+#define DATE_FORMAT "%m/%d/%Y - %H:%M:%S"
 
 //#define DEBUG
 
-bool	g_bHasPersonalSkinsZombie[MAXPLAYERS + 1] = { false, ... },
-		g_bHasPersonalSkinsHuman[MAXPLAYERS + 1] = { false, ... };
+/* CVARS */
+ConVar g_cvZombies; 
+ConVar g_cvHumans;
+ConVar g_cvFileSettingsPath;
+ConVar g_cvDownListPath;
 
-ConVar 	g_cvZombies, g_cvHumans,
-		g_cvFileSettingsPath, g_cvDownListPath,
-		g_cvClassIdentifierZombie, g_cvClassIdentifierHuman,
-		g_cvClassIdentifierZombieVIP, g_cvClassIdentifierHumanVIP;
+ConVar g_cvClassIdentifierZombie;
+ConVar g_cvClassIdentifierHuman;
+ConVar g_cvClassIdentifierZombieVIP;
+ConVar g_cvClassIdentifierHumanVIP;
+ConVar g_cvTeamMode;
 
-char 	g_sPlayerModelZombie[MAXPLAYERS+1][PLATFORM_MAX_PATH],
-		g_sPlayerModelHuman[MAXPLAYERS+1][PLATFORM_MAX_PATH],
-		g_sDownListPath[PLATFORM_MAX_PATH],
-		g_sFileSettingsPath[PLATFORM_MAX_PATH],
-		g_sClassIdentifierZombie[PLATFORM_MAX_PATH], g_sClassIdentifierHuman[PLATFORM_MAX_PATH],
-		g_sClassIdentifierZombieVIP[PLATFORM_MAX_PATH], g_sClassIdentifierHumanVIP[PLATFORM_MAX_PATH];
-
-KeyValues g_KV;
-
-public Plugin myinfo =
-{
-	name = "[ZR] Personal Skins",
-	description = "Gives a personal human or zombie skin",
-	author = "FrozDark, maxime1907, .Rushaway, Dolly, zaCade",
-	version = "2.1.0",
-	url = ""
+enum struct PlayerData {
+	bool hasZombie;
+	bool hasHuman;
+	
+	char modelZombie[PLATFORM_MAX_PATH];
+	char modelHuman[PLATFORM_MAX_PATH];
+	
+	int endZombie;
+	int endHuman;
+	
+	void Reset() {
+		this.hasZombie = false; 
+		this.hasHuman = false;
+		this.modelZombie[0] = '\0';
+		this.modelHuman[0] = '\0';
+		this.endZombie = 0;
+		this.endHuman = 0;
+	}
 }
 
-public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
-{
+PlayerData g_PlayerData[MAXPLAYERS + 1];
+
+/* Strings */
+char g_sFileSettingsPath[PLATFORM_MAX_PATH];
+
+char g_sClassIdentifierHuman[64];
+char g_sClassIdentifierZombie[64];
+char g_sClassIdentifierHumanVIP[64];
+char g_sClassIdentifierZombieVIP[64];
+
+/* Keyvalues */
+KeyValues g_hKV;
+
+public Plugin myinfo = {
+	name = "[ZR] Personal Skins",
+	description = "Gives a personal human or zombie skin",
+	author = "FrozDark, maxime1907, .Rushaway, Dolly, zaCade (Remade by Dolly)",
+	version = "2.2.2",
+	url = ""
+};
+
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max) {
 	RegPluginLibrary("ZR_PersonalSkins");
 	return APLRes_Success;
 }
 
-public void OnPluginStart()
-{
+public void OnPluginStart() {
+	RegConsoleCmd("sm_test3", cmd);
 	/* Paths Configs */
-	g_cvDownListPath = CreateConVar("zr_personalskins_downloadslist", "addons/sourcemod/configs/zr_personalskins_downloadslist.txt", "Config path of the download list", FCVAR_NONE);
-	g_cvFileSettingsPath = CreateConVar("zr_personalskins_skinslist", "addons/sourcemod/data/zr_personal_skins.txt", "Config path of the skin settings", FCVAR_NONE);
+	g_cvDownListPath 		= CreateConVar("zr_personalskins_downloadslist", "addons/sourcemod/configs/zr_personalskins_downloadslist.txt", "Config path of the download list", FCVAR_NONE);
+	g_cvFileSettingsPath 	= CreateConVar("zr_personalskins_skinslist", "addons/sourcemod/data/zr_personal_skins.txt", "Config path of the skin settings", FCVAR_NONE);
 
 	/* Enable - Disable */
-	g_cvZombies 	= CreateConVar("zr_personalskins_zombies_enable", "1", "Enable personal skin pickup for Zombies", _, true, 0.0, true, 1.0);
-	g_cvHumans 		= CreateConVar("zr_personalskins_humans_enable", "1", "Enable personal skin pickup for Humans", _, true, 0.0, true, 1.0);
+	g_cvZombies = CreateConVar("zr_personalskins_zombies_enable", "1", "Enable personal skin pickup for Zombies", _, true, 0.0, true, 1.0);
+	g_cvHumans 	= CreateConVar("zr_personalskins_humans_enable", "1", "Enable personal skin pickup for Humans", _, true, 0.0, true, 1.0);
 
 	/* Groups */
-	g_cvClassIdentifierZombie 	= CreateConVar("zr_personalskins_group_zombie", "Personal-Skin-Zombie", "Class identifier name for personal skin zombie", FCVAR_PROTECTED);
-	g_cvClassIdentifierHuman 	= CreateConVar("zr_personalskins_group_human", "Personal-Skin-Human", "Class identifier name for personal skin human", FCVAR_PROTECTED);
-	g_cvClassIdentifierZombieVIP = CreateConVar("zr_personalskins_group_zombie_vip", "Personal-Skin-Zombie-VIP", "Class identifier name for personal skin zombie VIP", FCVAR_PROTECTED);
-	g_cvClassIdentifierHumanVIP = CreateConVar("zr_personalskins_group_human_vip", "Personal-Skin-Human-VIP", "Class identifier name for personal skin human VIP", FCVAR_PROTECTED);
+	g_cvClassIdentifierZombie 		= CreateConVar("zr_personalskins_group_zombie", "Personal-Skin-Zombie", "Class identifier name for personal skin zombie", FCVAR_PROTECTED);
+	g_cvClassIdentifierHuman 		= CreateConVar("zr_personalskins_group_human", "Personal-Skin-Human", "Class identifier name for personal skin human", FCVAR_PROTECTED);
+	g_cvClassIdentifierZombieVIP 	= CreateConVar("zr_personalskins_group_zombie_vip", "Personal-Skin-Zombie-VIP", "Class identifier name for personal skin zombie VIP", FCVAR_PROTECTED);
+	g_cvClassIdentifierHumanVIP 	= CreateConVar("zr_personalskins_group_human_vip", "Personal-Skin-Human-VIP", "Class identifier name for personal skin human VIP", FCVAR_PROTECTED);
+	g_cvTeamMode 					= CreateConVar("zr_personalskins_team_mode", "0", "0: validation par class identifier, 1: validation par team (T=zm, CT=human)", FCVAR_NONE, true, 0.0, true, 1.0);
 
-	g_cvDownListPath.AddChangeHook(CvarChanges);
-	g_cvFileSettingsPath.AddChangeHook(CvarChanges);
-	g_cvClassIdentifierZombie.AddChangeHook(CvarChanges);
-	g_cvClassIdentifierHuman.AddChangeHook(CvarChanges);
-	g_cvClassIdentifierZombieVIP.AddChangeHook(CvarChanges);
-	g_cvClassIdentifierHumanVIP.AddChangeHook(CvarChanges);
-
+	g_cvFileSettingsPath			.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierZombie		.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierHuman		.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierZombieVIP	.AddChangeHook(OnConVarChange);
+	g_cvClassIdentifierHumanVIP		.AddChangeHook(OnConVarChange);
+	
 	/* Initialize values + Handle plugin reload */
-	GetConVarString(g_cvFileSettingsPath, g_sFileSettingsPath, sizeof(g_sFileSettingsPath));
-	GetConVarString(g_cvDownListPath, g_sDownListPath, sizeof(g_sDownListPath));
-	GetConVarString(g_cvClassIdentifierZombie, g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie));
-	GetConVarString(g_cvClassIdentifierHuman, g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman));
-	GetConVarString(g_cvClassIdentifierZombieVIP, g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP));
-	GetConVarString(g_cvClassIdentifierHumanVIP, g_sClassIdentifierHumanVIP, sizeof(g_sClassIdentifierHumanVIP));
-
+	g_cvFileSettingsPath			.GetString(g_sFileSettingsPath, sizeof(g_sFileSettingsPath));
+	g_cvClassIdentifierZombie		.GetString(g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie));
+	g_cvClassIdentifierHuman		.GetString(g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman));
+	g_cvClassIdentifierZombieVIP	.GetString(g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP));
+	g_cvClassIdentifierHumanVIP		.GetString(g_sClassIdentifierHumanVIP, sizeof(g_sClassIdentifierHumanVIP));
+	
 	RegAdminCmd("zr_pskins_reload", Command_Reload, ADMFLAG_ROOT);
 	RegConsoleCmd("sm_pskin", Command_pSkin);
 
 	AutoExecConfig(true, "zr_personal_skins", "zombiereloaded");
 }
 
-public void OnMapEnd()
-{
-	for (int i = 1; i <= MaxClients; i++)
-	{
-		if (!IsClientConnected(i))
-			continue;
+Action cmd(int client, int args) {
+	char date[120];
+	
+	FormatTime(date, sizeof(date), DATE_FORMAT, g_PlayerData[client].endHuman);
+	PrintToChat(client, date);
+	
+	FormatTime(date, sizeof(date), DATE_FORMAT, g_PlayerData[client].endZombie);
+	PrintToChat(client, date);
+	
+	PrintToChat(client, g_PlayerData[client].modelHuman);
+	PrintToChat(client, g_PlayerData[client].modelZombie);
 
-		if (!g_bHasPersonalSkinsZombie[i] || !g_bHasPersonalSkinsHuman[i])
-			continue;
+	return Plugin_Handled;
+}
+/* Map End */
+public void OnMapEnd() {
+	delete g_hKV;
 
-		g_sPlayerModelZombie[i] = "";
-		g_sPlayerModelHuman[i] = "";
-	}
-
-	delete g_KV;
-
-	// Restore cvar to 1
+	// Restore cvar to 1, this is helpful when a specified team (or both) personal skin is/are disabled during a map, somehow cvars stay with the same value
 	g_cvZombies.IntValue = 1;
 	g_cvHumans.IntValue = 1;
 }
 
-public void OnConfigsExecuted()
-{
-	g_cvFileSettingsPath.GetString(g_sFileSettingsPath, sizeof(g_sFileSettingsPath));
-	g_cvDownListPath.GetString(g_sDownListPath, sizeof(g_sDownListPath));
-
-	g_KV = new KeyValues("SkinSettings");
-	
-	if(!g_KV.ImportFromFile(g_sFileSettingsPath))
-	{
-		SetFailState("File '%s' not found!", g_sFileSettingsPath);
-		delete g_KV;
-		return;
-	}
-	
-	if(!FileExists(g_sDownListPath, false))
-	{
-		LogError("Downloadslist '%s' not found", g_sDownListPath);
-		return;
-	}
-	
-	File_ReadDownloadList(g_sDownListPath);
+/* Client Disconnect */
+public void OnClientDisconnect(int client) {
+	g_PlayerData[client].Reset();
 }
 
-public void CvarChanges(ConVar convar, const char[] oldValue, const char[] newValue)
-{
-	if (convar == g_cvFileSettingsPath)
-	{
-		if(g_KV == null)
-			return;
+/* Read the data file */
+public void OnConfigsExecuted() {
+	char downloadPath[PLATFORM_MAX_PATH];
+	g_cvDownListPath.GetString(downloadPath, sizeof(downloadPath));
 
+	g_hKV = new KeyValues("SkinSettings");
+	
+	if(!g_hKV.ImportFromFile(g_sFileSettingsPath)) {
+		SetFailState("[ZR-Personal Skins] File '%s' not found!", g_sFileSettingsPath);
+		delete g_hKV;
+		return;
+	}
+	
+	if(!FileExists(downloadPath, false))
+	{
+		LogError("[ZR-Personal Skins] Downloadslist '%s' not found", downloadPath);
+		return;
+	}
+	
+	File_ReadDownloadList(downloadPath);
+}
+
+/* Update settings path when it is changed */
+public void OnConVarChange(ConVar convar, const char[] oldValue, const char[] newValue) {
+	if(convar == g_cvFileSettingsPath) {
 		strcopy(g_sFileSettingsPath, sizeof(g_sFileSettingsPath), newValue);
-		ClearKV(g_KV);
-
-		if (!g_KV.ImportFromFile(g_sFileSettingsPath))
-			SetFailState("File '%s' not found!", g_sFileSettingsPath);
-
+		ClearKV(g_hKV);
+		
+		if (!g_hKV.ImportFromFile(g_sFileSettingsPath)) {
+			SetFailState("[ZR-Personal Skins] File '%s' not found!", g_sFileSettingsPath);
+		}
+		
+		return;
+	}
+	
+	if (convar == g_cvClassIdentifierZombie) {
+		strcopy(g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie), newValue);
+		return;
+	}
+	
+	if(convar == g_cvClassIdentifierHuman) {
+		strcopy(g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman), newValue);
+		return;
+	}
+	
+	if (convar == g_cvClassIdentifierZombieVIP) {
+		strcopy(g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP), newValue);
 		return;
 	}
 
-	else if (convar == g_cvDownListPath)
-	{
-		strcopy(g_sDownListPath, sizeof(g_sDownListPath), newValue);
-		if(!FileExists(g_sDownListPath, false))
-			return;
-
-		File_ReadDownloadList(g_sDownListPath);
-	}
-
-	else if (convar == g_cvClassIdentifierZombie)
-		strcopy(g_sClassIdentifierZombie, sizeof(g_sClassIdentifierZombie), newValue);
-
-	else if (convar == g_cvClassIdentifierHuman)
-		strcopy(g_sClassIdentifierHuman, sizeof(g_sClassIdentifierHuman), newValue);
-
-	else if (convar == g_cvClassIdentifierZombieVIP)
-		strcopy(g_sClassIdentifierZombieVIP, sizeof(g_sClassIdentifierZombieVIP), newValue);
-
-	else if (convar == g_cvClassIdentifierHumanVIP)
+	if (convar == g_cvClassIdentifierHumanVIP) {
 		strcopy(g_sClassIdentifierHumanVIP, sizeof(g_sClassIdentifierHumanVIP), newValue);
+		return;
+	}
 }
 
-public Action Command_Reload(int client, int args)
-{
-	if(FileExists(g_sDownListPath, false))
-	{
-		File_ReadDownloadList(g_sDownListPath);
-	
-		CReplyToCommand(client, "{green}[ZR] {default}Successfully reloaded Personal-Skin List.");
-		LogAction(-1, -1, "[ZR-PersonalSkin] %L Reloaded the Personal-Skin List.", client);
-	}
-
-	if(g_KV == null)
+/* Commands */
+public Action Command_Reload(int client, int args) {
+	if(g_hKV == null) {
 		return Plugin_Handled;
-
-	ClearKV(g_KV);
-	if(!g_KV.ImportFromFile(g_sFileSettingsPath))
-	{
-		SetFailState("File '%s' not found!", g_sFileSettingsPath);
-		CReplyToCommand(client, "{green}[ZR] {red}File '%' not found!", g_sFileSettingsPath);
 	}
 
+	ClearKV(g_hKV);
+	if(!g_hKV.ImportFromFile(g_sFileSettingsPath)) {
+		CReplyToCommand(client, "{green}[ZR] {red}File '%s' not found!", g_sFileSettingsPath);
+		SetFailState("[ZR-Personal Skins] File '%s' not found!", g_sFileSettingsPath);
+		return Plugin_Handled;
+	}
+	
+	CReplyToCommand(client, "{green}[ZR] {default}Successfully reloaded Personal-Skin List.");
+	LogAction(-1, -1, "[ZR-PersonalSkin] %L Reloaded the Personal-Skin List.", client);
 	return Plugin_Handled;
 }
 
-public Action Command_pSkin(int client, int args)
-{
-	if (!client)
+public Action Command_pSkin(int client, int args) {
+	if (!client) {
 		return Plugin_Handled;
+	}
 
-	if (!g_bHasPersonalSkinsZombie[client] && !g_bHasPersonalSkinsHuman[client])
+	if (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman) {
 		CReplyToCommand(client, "{green}[ZR] {default}You don't have personal-skin");
-	else
+	} else {
 		ZR_MenuClass(client);
-
+	}
+	
 	return Plugin_Handled;
 }
 
 // We use this instead of PostAdminCheck, bcs ZombieReloaded check class on post.
 // Need to give the groups used as filter in playerclass before ZR check if user can access to it.
-public void OnClientPostAdminFilter(int client)
-{
-	if (g_KV == null || !client || IsClientSourceTV(client) || IsFakeClient(client))
+public void OnClientPostAdminFilter(int client) {
+	if (g_hKV == null || IsFakeClient(client)) {
 		return;
-
-	ResetClient(client);
-
-	char sSteamID[24], sIP[16], sName[64];
-
-	if(!GetClientIP(client, sIP, sizeof(sIP), true) || !GetClientAuthId(client, AuthId_Steam2, sSteamID, sizeof(sSteamID)) || !GetClientName(client, sName, sizeof(sName)))
-		return;
-
-	g_KV.Rewind();
-	if(!g_KV.JumpToKey(sSteamID) && g_KV.JumpToKey(sIP) && g_KV.JumpToKey(sName))
-		return;
-
-	g_KV.GetString("ModelZombie", g_sPlayerModelZombie[client], PLATFORM_MAX_PATH);
-	g_KV.GetString("ModelHuman", g_sPlayerModelHuman[client], PLATFORM_MAX_PATH);
-
-	if(strlen(g_sPlayerModelZombie[client][0]) != 0)
-	{
-		if (!IsModelFile(g_sPlayerModelZombie[client]))
-		{
-			LogError("%L Personal Skins (Zombie) is not a model file. (.mdl)", client);
-			return;
-		}
-
-		if (!IsModelPrecached(g_sPlayerModelZombie[client]))
-			PrecacheModel(g_sPlayerModelZombie[client], false);
-
-		g_bHasPersonalSkinsZombie[client] = true;
 	}
-
-	if (strlen(g_sPlayerModelHuman[client][0]) != 0)
-	{
-		if (!IsModelFile(g_sPlayerModelHuman[client]))
-		{
-			LogError("%L Personal Skins (Human) is not a model file. (.mdl)", client);
-			return;
-		}
-
-		if(!IsModelPrecached(g_sPlayerModelHuman[client]))
-			PrecacheModel(g_sPlayerModelHuman[client], false);
 	
-		g_bHasPersonalSkinsHuman[client] = true;
-	}
+	char steamID[24], ip[16], name[64];
 
-	// No personal-skin found for this player - Stop here
-	if (!g_bHasPersonalSkinsHuman[client] && !g_bHasPersonalSkinsZombie[client])
+	if(!GetClientIP(client, ip, sizeof(ip), true) || !GetClientAuthId(client, AuthId_Steam2, steamID, sizeof(steamID)) || !GetClientName(client, name, sizeof(name)))
 		return;
+
+	g_hKV.Rewind();
+	if(!g_hKV.JumpToKey(steamID) && !g_hKV.JumpToKey(ip) && !g_hKV.JumpToKey(name)) {
+		return;
+	}
+	
+	/* Get Zombie Personal Skin Info */
+	int zmSkinEndTime;
+	if(ValidatePersonalSkin(client, "ModelZombie", "end_zombie", g_PlayerData[client].modelZombie, sizeof(PlayerData::modelZombie), zmSkinEndTime)) {
+		g_PlayerData[client].hasZombie = true;
+		if(zmSkinEndTime > 0) {
+			g_PlayerData[client].endZombie = zmSkinEndTime;
+		}
+	} else {
+		#if defined DEBUG
+		PrintToServer("[ZR-Personal Skins] Could not Validate Zombie skin for %N, skin has probably ended", client);
+		#endif
+	}
+	
+	int humanEndTime;
+	if(ValidatePersonalSkin(client, "ModelHuman", "end_human", g_PlayerData[client].modelHuman, sizeof(PlayerData::modelHuman), humanEndTime)) {
+		g_PlayerData[client].hasHuman = true;
+		if(humanEndTime > 0) {
+			g_PlayerData[client].endHuman = humanEndTime;
+		}
+	} else {
+		#if defined DEBUG
+		PrintToServer("[ZR-Personal Skins] Could not Validate Human skin for %N, skin has probably ended", client);
+		#endif
+	}
+	
+	// No personal-skin found for this player - Stop here
+	if (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman) {
+		return;
+	}
 
 	GrantCustom5Flag(client);
 }
 
-public void OnRebuildAdminCache(AdminCachePart part)
-{
-	if (part != AdminCache_Admins)
-		return;
+/* To validate if the player can use the personal skin or not */
+bool ValidatePersonalSkin(int client, const char[] modelKey, const char[] endKey, char[] model, int maxlen, int &skinEndTime = 0) {
+	if(g_hKV.GetString(modelKey, model, maxlen)
+		&& strlen(model) != 0) {
+		bool has = false;
+		char endTime[24];
+		PrintToServer("#1: Success");
+		g_hKV.GetString(endKey, endTime, sizeof(endTime));
+		if(endTime[0]) {
+			// for end time (useful if skin was rewarded during an event and there is an end for it)
+			// be careful with the date format otherwise the function will return an error
+			#if defined DEBUG
+			PrintToServer("[ZR-Personal Skins] End Time for %N: %s", client, endTime);
+			#endif
+			int endTimeStamp = ParseTime(endTime, DATE_FORMAT);
+			if(endTimeStamp > GetTime()) {
+				has = true;
+				skinEndTime = endTimeStamp;
+				PrintToServer("End Time Int1: %d", skinEndTime);
+			}
+		} else {
+			has = true;
+		}
+		
+		if(has) {
+			if (!IsModelFile(model))
+			{
+				LogError("[ZR-Personal Skins] %L Personal Skins (Zombie) is not a model file. (.mdl)", client);
+				has = false;
+				PrintToServer("#2: Error");
+			}
 
-	for (int client = 1; client <= MaxClients; client++)
-	{
-		if (!IsClientInGame(client))
+			if (has && !IsModelPrecached(model)) {
+				PrecacheModel(model, false);
+			}
+
+			return has;
+		}
+	}
+	
+	return false;
+}
+
+public void OnRebuildAdminCache(AdminCachePart part) {
+	if (part != AdminCache_Admins) {
+		return;
+	}
+
+	for (int client = 1; client <= MaxClients; client++) {
+		if (!IsClientInGame(client) || IsFakeClient(client) || (!g_PlayerData[client].hasZombie && !g_PlayerData[client].hasHuman)) {
 			continue;
-		if (IsFakeClient(client))
-			continue;
-		if (IsClientSourceTV(client))
-			continue;
-		if (!g_bHasPersonalSkinsZombie[client] && !g_bHasPersonalSkinsHuman[client])
-			continue;
+		}
 
 		GrantCustom5Flag(client);
 	}
 }
 
-stock void GrantCustom5Flag(int client)
-{
+void GrantCustom5Flag(int client) {
 	int flags = GetUserFlagBits(client);
-	if (!(flags & ADMFLAG_CUSTOM5))
-	{
+	if (!(flags & ADMFLAG_CUSTOM5)) {
 		flags |= ADMFLAG_CUSTOM5;
 		SetUserFlagBits(client, flags);
-		LogMessage("Granted custom5 flag to %L", client);
+		LogMessage("[ZR-Personal Skins] Granted custom5 flag to %L", client);
 	}
 }
 
-public void ZR_OnClassAttributesApplied(int &client, int &classindex)
-{
+public void ZR_OnClassAttributesApplied(int &client, int &classindex) {
 	#if defined DEBUG
-	LogMessage("ZR_OnClassAttributesApplied: %d | %d", client, classindex);
+	LogMessage("[ZR-Personal Skins] ZR_OnClassAttributesApplied: %d | %d", client, classindex);
 	#endif
 
-	if(IsValidClient(client) && IsPlayerAlive(client) && (g_bHasPersonalSkinsZombie[client] || g_bHasPersonalSkinsHuman[client]))
-	{
-		// Small workaround to prevent #10 - https://github.com/srcdslab/sm-plugin-ZR_PersonalSkins/issues/10
-		int iActiveClass = -1;
-
-		if (client && IsPlayerAlive(client))
-			iActiveClass = ZR_GetActiveClass(client);
-		else
-			return;
-
-		int iPersonalHumanClass = ZR_GetClassByIdentifier(g_sClassIdentifierHuman);
-		int iPersonalZombieClass = ZR_GetClassByIdentifier(g_sClassIdentifierZombie);
-		int iPersonalHumanClassVIP = ZR_GetClassByIdentifier(g_sClassIdentifierHumanVIP);
-		int iPersonalZombieClassVIP = ZR_GetClassByIdentifier(g_sClassIdentifierZombieVIP);
-
-		#if defined DEBUG
-		LogMessage("%N has active class %d", client, iActiveClass);
-		LogMessage("Personal human: %d", iPersonalHumanClass);
-		LogMessage("Personal zombie: %d", iPersonalZombieClass);
-		LogMessage("Personal human VIP: %d", iPersonalHumanClassVIP);
-		LogMessage("Personal zombie VIP: %d", iPersonalZombieClassVIP);
-		#endif
-
-		// If user is not using a Personal-Skin, stop here.
-		if (ZR_IsValidClassIndex(iActiveClass) && (!(iActiveClass == iPersonalHumanClass || iActiveClass == iPersonalZombieClass || iActiveClass == iPersonalHumanClassVIP || iActiveClass == iPersonalZombieClassVIP)))
-			return;
-
-		char modelpath[PLATFORM_MAX_PATH];
-		if (ZR_IsClientZombie(client) && ZR_IsValidClassIndex(iActiveClass) && (iActiveClass == iPersonalZombieClass || iActiveClass == iPersonalZombieClassVIP))
-			Format(modelpath, sizeof(modelpath), g_sPlayerModelZombie[client][0]);
-		else if (ZR_IsClientHuman(client) && ZR_IsValidClassIndex(iActiveClass) && (iActiveClass == iPersonalHumanClass || iActiveClass == iPersonalHumanClassVIP))
-			Format(modelpath, sizeof(modelpath), g_sPlayerModelHuman[client][0]);
-		else
-			return;
-
-		// Player has a Personal-Skin but no model related to the current team or model_path wasn't set.
-		if (strlen(modelpath) == 0)
-			return;
-
-		#if defined DEBUG
-		LogMessage("%L new model path stored: %s", client, modelpath);
-		#endif
+	if(!IsValidClient(client) || !IsPlayerAlive(client) || !(g_PlayerData[client].hasZombie || g_PlayerData[client].hasHuman)) {
+		return;
+	}
 	
-		if (!IsModelFile(modelpath))
-		{
-			PrintToChat(client, "[SM] A configuration error was caught on your model, can't apply it.");
-			LogError("Model extension is not an .mdl (%s)", modelpath);
-			return;
-		}
-
-		// Should never happen, but to be safe attempt hotfix on the fly
-		if (!IsModelPrecached(modelpath))
-		{
-			PrecacheModel(modelpath);
-			#if defined DEBUG
-			LogMessage("Model not precached, attempting an hotfix by Precaching the model on the fly.. (%s)", modelpath);
-			#endif
-
-			if (!IsModelPrecached(modelpath))
-			{
-				PrintToChat(client, "[SM] A technical error was caught on your model, can't apply it.");
-				LogError("Model not precached, not applying model.. \"%s\"", modelpath);
+	int activeClass = ZR_GetActiveClass(client);
+	
+	int personalHumanClass 		= ZR_GetClassByIdentifier(g_sClassIdentifierHuman);
+	int personalZombieClass 	= ZR_GetClassByIdentifier(g_sClassIdentifierZombie);
+	int personalHumanClassVIP 	= ZR_GetClassByIdentifier(g_sClassIdentifierHumanVIP);
+	int	personalZombieClassVIP 	= ZR_GetClassByIdentifier(g_sClassIdentifierZombieVIP);
+	
+	#if defined DEBUG
+		LogMessage("[ZR-Personal Skins] %N has active class %d", client, activeClass);
+		LogMessage("[ZR-Personal Skins] Personal human: %d", personalHumanClass);
+		LogMessage("[ZR-Personal Skins] Personal zombie: %d", personalZombieClass);
+		LogMessage("[ZR-Personal Skins] Personal human VIP: %d", personalHumanClassVIP);
+		LogMessage("[ZR-Personal Skins] Personal zombie VIP: %d", personalZombieClassVIP);
+	#endif
+	
+	
+	char modelpath[PLATFORM_MAX_PATH];
+	switch (g_cvTeamMode.IntValue) {
+		case 0: {
+			if(!ZR_IsValidClassIndex(activeClass)) {
+				return;
+			}
+			
+			// If user is not using a Personal-Skin, stop here.
+			if (
+				!(activeClass == personalHumanClass 
+				|| activeClass == personalZombieClass 
+				|| activeClass == personalHumanClassVIP 
+				|| activeClass == personalZombieClassVIP)
+			) {
 				return;
 			}
 
-			#if defined DEBUG
-			LogMessage("Hotfix: Model has been preached.. Yay! (%s)", modelpath);
-			#endif
+			if (ZR_IsClientZombie(client) && g_cvZombies.BoolValue && (activeClass == personalZombieClass || activeClass == personalZombieClassVIP)) {
+				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelZombie);
+			} else if(ZR_IsClientHuman(client) && g_cvHumans.BoolValue && (activeClass == personalHumanClass || activeClass == personalHumanClassVIP)) {
+				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelHuman);
+			}
+		}
+		
+		case 1: {
+			int team = GetClientTeam(client);
+			if (team == 2 && g_cvZombies.BoolValue && g_PlayerData[client].hasZombie)
+				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelZombie);
+			else if (team == 3 && g_cvHumans.BoolValue && g_PlayerData[client].hasHuman)
+				strcopy(modelpath, sizeof(modelpath), g_PlayerData[client].modelHuman);
+		}
+		
+		default: return;
+	}
+
+	// Player has a Personal-Skin but no model related to the current team or model_path wasn't set.
+	if (strlen(modelpath) == 0)
+		return;
+
+	#if defined DEBUG
+	LogMessage("[ZR-Personal Skins] %L new model path stored: %s", client, modelpath);
+	#endif
+
+	if (!IsModelFile(modelpath))
+	{
+		PrintToChat(client, "[SM] A configuration error was caught on your model, can't apply it.");
+		LogError("[ZR-Personal Skins] Model extension is not an .mdl (%s)", modelpath);
+		return;
+	}
+
+	// Should never happen, but to be safe attempt hotfix on the fly
+	if (!IsModelPrecached(modelpath))
+	{
+		PrecacheModel(modelpath);
+		#if defined DEBUG
+		LogMessage("[ZR-Personal Skins] Model not precached, attempting an hotfix by Precaching the model on the fly.. (%s)", modelpath);
+		#endif
+
+		if (!IsModelPrecached(modelpath))
+		{
+			PrintToChat(client, "[SM] A technical error was caught on your model, can't apply it.");
+			LogError("[ZR-Personal Skins] Model not precached, not applying model.. \"%s\"", modelpath);
+			return;
 		}
 
-		SetEntityModel(client, modelpath);
-	}
-}
-
-public void OnClientDisconnect(int client)
-{
-	ResetClient(client);
-}
-
-stock void ClearKV(KeyValues kvHandle)
-{
-	if(kvHandle == null)
-		return;
-
-	kvHandle.Rewind();
-
-	if(!kvHandle.GotoFirstSubKey())
-		return;
-
-	do 
-	{
-		kvHandle.DeleteThis();
-		kvHandle.Rewind();
+		#if defined DEBUG
+		LogMessage("[ZR-Personal Skins] Hotfix: Model has been preached.. Yay! (%s)", modelpath);
+		#endif
 	}
 
-	while(kvHandle.GotoNextKey());
-	kvHandle.Rewind();
+	SetEntityModel(client, modelpath);
 }
 
-stock bool IsModelFile(char[] model)
-{
+void ClearKV(KeyValues kv) {
+	if(kv == null) {
+		return;
+	}
+	
+	kv.Rewind();
+
+	if(!kv.GotoFirstSubKey()) {
+		return;
+	}
+
+	do {
+		kv.DeleteThis();
+		kv.Rewind();
+	}
+
+	while(kv.GotoNextKey());
+	kv.Rewind();
+}
+
+bool IsModelFile(char[] model) {
 	char buf[4];
 	GetExtension(model, buf, sizeof(buf));
 	return !strcmp(buf, "mdl", false);
 }
 
-stock void GetExtension(char[] path, char[] buffer, int size)
-{
+void GetExtension(char[] path, char[] buffer, int size) {
 	int extpos = FindCharInString(path, '.', true);
-	if (extpos == -1)
-	{
+	if (extpos == -1) {
 		buffer[0] = '\0';
 		return;
 	}
+	
 	extpos++;
 	strcopy(buffer, size, path[extpos]);
-}
-
-stock void ResetClient(int client)
-{
-	g_bHasPersonalSkinsZombie[client] = false;
-	g_bHasPersonalSkinsHuman[client] = false;
-	g_sPlayerModelZombie[client] = "";
-	g_sPlayerModelHuman[client] = "";
 }


### PR DESCRIPTION
- Fixed Enable/Disable cvars were never used in the new version
- Added "end_zombie" and "end_human" on settings cfg, this is to specify if a personal skin should end at a desired time.
- End time uses this date format: %m/%d/%Y - %H:%M:%S
- For example: "end_human"   "08/04/2025 - 09:23:00"